### PR TITLE
494 fix inventory parsing when no labels available

### DIFF
--- a/plugins/inventory/gcp_compute.py
+++ b/plugins/inventory/gcp_compute.py
@@ -231,7 +231,8 @@ class GcpInstance(object):
         for order in self.hostname_ordering:
             name = None
             if order.startswith("labels."):
-                name = self.json[u"labels"].get(order[7:])
+                if "labels" in self.json:
+                    name = self.json[u"labels"].get(order[7:])
             elif order == "public_ip":
                 name = self._get_publicip()
             elif order == "private_ip":


### PR DESCRIPTION
Fix for https://github.com/ansible-collections/google.cloud/issues/494

If no labels are available, continue parsing with the next entries in the ordered list.